### PR TITLE
node: explicitly install ffi module via npm

### DIFF
--- a/node-to-rust/Makefile
+++ b/node-to-rust/Makefile
@@ -4,12 +4,16 @@ else
     EXT := so
 endif
 
-all: target/libdouble_input.$(EXT)
+all: target/libdouble_input.$(EXT) node_modules/ffi
 	node src/main.js
 
 target/libdouble_input.$(EXT): src/lib.rs Cargo.toml
 	cargo build
 	(cd target && ln -nsf debug/libdouble_input-*$(EXT) libdouble_input.$(EXT))
 
+node_modules/ffi:
+	npm install ffi
+
 clean:
 	rm -rf target
+	rm -rf node_modules


### PR DESCRIPTION
Currently `make` fails unless Node's `ffi` module was (manually) installed in advance.
This should fix it.
