### PR TITLE
Use gcc::Build instead of gcc::Config

### DIFF
--- a/rust-to-c/Cargo.toml
+++ b/rust-to-c/Cargo.toml
@@ -8,4 +8,4 @@ build = "build.rs"
 libc = "0.1"
 
 [build-dependencies]
-gcc = "0.3"
+cc = "1.0"

--- a/rust-to-c/build.rs
+++ b/rust-to-c/build.rs
@@ -1,5 +1,7 @@
-extern crate gcc;
+extern crate cc;
 
 fn main() {
-    gcc::Config::new().file("src/double.c").compile("libdouble.a");
+    cc::Build::new()
+        .file("src/double.c")
+        .compile("libdouble.a");
 }


### PR DESCRIPTION
Hi @alexcrichton, 

Thank you for nice examples.
I got a deprecation warning
```
warning: use of deprecated item: gcc::Config has been renamed to gcc::Build
 --> build.rs:4:5
  |
4 |     gcc::Config::new().file("src/double.c").compile("libdouble.a");
  |     ^^^^^^^^^^^^^^^^
  |
  = note: #[warn(deprecated)] on by default
```
I guess it would be better to update the example.