### PR TITLE
Add Swift to Rust example.

### DIFF
--- a/swift-to-rust/Cargo.toml
+++ b/swift-to-rust/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "swift-to-rust"
+version = "0.1.0"
+authors = ["Calvin Hill <calvin@hakobaito.co.uk>"]
+
+[lib]
+name = "double_input"
+crate-type = ["dylib"]

--- a/swift-to-rust/Makefile
+++ b/swift-to-rust/Makefile
@@ -1,0 +1,15 @@
+ifeq ($(shell uname),Darwin)
+    EXT := dylib
+else
+    EXT := so
+endif
+
+all: target/debug/libdouble_input.$(EXT)
+	swiftc src/main.swift -import-objc-header src/double.h -L./target/debug -ldouble_input -o double
+	LD_LIBRARY_PATH=./target/debug ./double
+
+target/debug/libdouble_input.$(EXT): src/lib.rs Cargo.toml
+	cargo build
+
+clean:
+	rm -rf target double

--- a/swift-to-rust/src/double.h
+++ b/swift-to-rust/src/double.h
@@ -1,0 +1,1 @@
+int double_input(int input);

--- a/swift-to-rust/src/lib.rs
+++ b/swift-to-rust/src/lib.rs
@@ -1,0 +1,4 @@
+#[no_mangle]
+pub extern fn double_input(input: i32) -> i32 {
+    input * 2
+}

--- a/swift-to-rust/src/main.swift
+++ b/swift-to-rust/src/main.swift
@@ -1,0 +1,1 @@
+print(double_input(2))


### PR DESCRIPTION
A very minimal example of calling from Swift to Rust code. Works on both macOS and Linux.