### PR TITLE
Add Crystal to Rust example.

### DIFF
--- a/crystal-to-rust/Cargo.toml
+++ b/crystal-to-rust/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "crystal-to-rust"
+version = "0.1.0"
+authors = ["Calvin Hill <calvin@hakobaito.co.uk>"]
+
+[lib]
+name = "double_input"
+crate-type = ["dylib"]

--- a/crystal-to-rust/Makefile
+++ b/crystal-to-rust/Makefile
@@ -1,0 +1,16 @@
+ifeq ($(shell uname),Darwin)
+    EXT := dylib
+else
+    EXT := so
+endif
+
+all: target/debug/libdouble_input.$(EXT)
+	LIBRARY_PATH=$(PWD)/target/debug:$(LIBRARY_PATH) crystal build src/double.cr -o double
+	LD_LIBRARY_PATH=./target/debug ./double
+
+target/debug/libdouble_input.$(EXT): src/lib.rs Cargo.toml
+	cargo build
+	cd src
+
+clean:
+	rm -rf target double double.dwarf

--- a/crystal-to-rust/src/double.cr
+++ b/crystal-to-rust/src/double.cr
@@ -1,0 +1,6 @@
+@[Link("double_input")]
+lib RustLib
+    fun double_input(input: Int32) : Int32
+end
+
+puts RustLib.double_input(2)

--- a/crystal-to-rust/src/lib.rs
+++ b/crystal-to-rust/src/lib.rs
@@ -1,0 +1,4 @@
+#[no_mangle]
+pub extern "C" fn double_input(input: i32) -> i32 {
+    input * 2
+}


### PR DESCRIPTION
This adds another FFI example, but for calling from Crystal to Rust code. Works on macOS and Linux.