### PR TITLE
Add C# to Rust example

### DIFF
--- a/csharp-to-rust/.gitignore
+++ b/csharp-to-rust/.gitignore
@@ -1,0 +1,3 @@
+/target
+**/*.rs.bk
+Cargo.lock

--- a/csharp-to-rust/Cargo.toml
+++ b/csharp-to-rust/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "csharp-to-rust"
+version = "0.1.0"
+authors = ["Wesley Hill <wesley@hakobaito.co.uk>"]
+
+[lib]
+name = "double_input"
+crate-type = ["cdylib"]

--- a/csharp-to-rust/Makefile
+++ b/csharp-to-rust/Makefile
@@ -1,0 +1,9 @@
+all: target/debug/libdouble_input
+	csc src/double.cs
+	mono ./double.exe
+
+target/debug/libdouble_input: src/lib.rs Cargo.toml
+	rustc --crate-name double_input src/lib.rs --crate-type cdylib -o libdouble_input
+
+clean:
+	rm -rf target double.exe

--- a/csharp-to-rust/src/double.cs
+++ b/csharp-to-rust/src/double.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace DoubleClass {
+
+    class Double {
+        [DllImport ("libdouble_input")]
+        public static extern int double_input (int input);
+
+
+        public static void Main (string[] args) {
+            Console.WriteLine (double_input (2));
+        }
+    }
+}

--- a/csharp-to-rust/src/lib.rs
+++ b/csharp-to-rust/src/lib.rs
@@ -1,0 +1,4 @@
+#[no_mangle]
+pub extern fn double_input(input: i32) -> i32 {
+    input * 2
+}


### PR DESCRIPTION
Tested on Mac, Windows (WSL) and Linux. All using mono.